### PR TITLE
Skip OPENSSL_cpuid_setup when replaying.

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -337,6 +337,7 @@ add_library(
   rand_extra/rand_extra.c
   rand_extra/windows.c
   rc4/rc4.c
+  record_replay.c
   refcount_c11.c
   refcount_lock.c
   rsa_extra/rsa_asn1.c

--- a/crypto/record_replay.c
+++ b/crypto/record_replay.c
@@ -1,0 +1,38 @@
+#include "record_replay.h"
+
+#ifndef _WIN32
+#include <dlfcn.h>
+#else
+#include <libloaderapi.h>
+#endif
+
+static void* LookupRecordReplaySymbol(const char* name) {
+#ifndef _WIN32
+  void* fnptr = dlsym(RTLD_DEFAULT, name);
+#else
+  HMODULE module = GetModuleHandleA("windows-recordreplay.dll");
+  void* fnptr = module ? (void*)GetProcAddress(module, name) : NULL;
+#endif
+  return fnptr ? fnptr : (void*)1;
+}
+
+int RecordReplay_IsRecordingOrReplaying(void) {
+  static void* fnptr;
+  if (!fnptr) {
+    fnptr = LookupRecordReplaySymbol("RecordReplayAssert");
+  }
+  return fnptr != (void*)1;
+}
+
+int RecordReplay_IsReplaying(void) {
+  static void* fnptr;
+  if (!fnptr) {
+    fnptr = LookupRecordReplaySymbol("RecordReplayIsReplaying");
+  }
+  if (fnptr == (void*)1) {
+    return 0;
+  }
+
+  typedef int (*RecordReplayIsReplayingFn)(void);
+  return ((RecordReplayIsReplayingFn)fnptr)();
+}

--- a/crypto/record_replay.h
+++ b/crypto/record_replay.h
@@ -1,0 +1,7 @@
+#ifndef OPENSSL_HEADER_RECORD_REPLAY_H
+#define OPENSSL_HEADER_RECORD_REPLAY_H
+
+int RecordReplay_IsRecordingOrReplaying(void);
+int RecordReplay_IsReplaying(void);
+
+#endif // OPENSSL_HEADER_RECORD_REPLAY_H


### PR DESCRIPTION
For RUN-1614 (https://linear.app/replay/issue/RUN-1614/skip-checking-cpuid-during-replay-in-boringssl-bypassing-openssl-cpuid)
