### PR TITLE
Windows build broken.

### DIFF
--- a/crypto/record_replay.c
+++ b/crypto/record_replay.c
@@ -3,7 +3,7 @@
 #ifndef _WIN32
 #include <dlfcn.h>
 #else
-#include <libloaderapi.h>
+#include <windows.h>
 #endif
 
 static void* LookupRecordReplaySymbol(const char* name) {


### PR DESCRIPTION
Try using different header file for `GetModuleHandleA`.

Please do not send pull requests to the BoringSSL repository.

We do, however, take contributions gladly.

See https://boringssl.googlesource.com/boringssl/+/master/CONTRIBUTING.md

Thanks!
